### PR TITLE
remove negation operator to fix the logic error

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultSaveOrUpdateEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultSaveOrUpdateEventListener.java
@@ -123,7 +123,7 @@ public class DefaultSaveOrUpdateEventListener extends AbstractSaveEventListener 
 			}
 			else {
 
-				final boolean isEqual = !entityEntry.getPersister().getIdentifierType()
+				final boolean isEqual = entityEntry.getPersister().getIdentifierType()
 						.isEqual( requestedId, entityEntry.getId(), factory );
 
 				if ( isEqual ) {


### PR DESCRIPTION
I think the following code snippet has obvious logic error:
`
				final boolean isEqual = !entityEntry.getPersister().getIdentifierType()
						.isEqual( requestedId, entityEntry.getId(), factory );

				if ( isEqual ) {
					throw new PersistentObjectException(
							"object passed to save() was already persistent: " +
									MessageHelper.infoString( entityEntry.getPersister(), requestedId, factory )
					);
				}
`
So if the explicit 'requestedId' in the `SaveOrUpdateEvent` is different than the persistent entity entry's id, no exception should be thrown for that is designed feature. Seems the `!` operator is overlooked. Also, the logging statement is only making sense when both ids are equal!!